### PR TITLE
Workaround when QDockWidget gets detached

### DIFF
--- a/src/Vizkit3DWidget.cpp
+++ b/src/Vizkit3DWidget.cpp
@@ -396,9 +396,9 @@ osgQt::GraphicsWindowQt* Vizkit3DWidget::createGraphicsWindow( int x, int y, int
     return new osgQt::GraphicsWindowQt(traits.get());
 }
 
-void Vizkit3DWidget::paintEvent( QPaintEvent* event )
+void Vizkit3DWidget::update()
 {
-    //frame();
+    QWidget::update();
     osgviz->update();
 }
 

--- a/src/Vizkit3DWidget.hpp
+++ b/src/Vizkit3DWidget.hpp
@@ -242,6 +242,7 @@ namespace vizkit3d
             void setCameraManipulator(osg::ref_ptr<osgGA::CameraManipulator> manipulator, bool resetToDefaultHome = false);
 
         public slots:
+            void update();
             void addPlugin(QObject* plugin, QObject* parent = NULL);
             void removePlugin(QObject* plugin);
 
@@ -410,9 +411,6 @@ namespace vizkit3d
             /** This signal is emitted when the user selects a frame in the
              *  3d view.*/
             void frameSelected(const QString frame);
-
-        protected:
-            virtual void paintEvent( QPaintEvent* event );
 
         private slots:
             void setPluginDataFrameIntern(const QString &frame, QObject *plugin);


### PR DESCRIPTION
@arneboe This seems to be sufficient to fix my problem. I can't tell if it breaks something else.